### PR TITLE
Fix responsive grid layout on small screens

### DIFF
--- a/media/css/main.css
+++ b/media/css/main.css
@@ -520,13 +520,13 @@ main {
 	display: grid;
 	max-width: 1350px;
 	padding: 0 1rem;
-	grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(min(400px, 100%), 1fr));
 	grid-gap: 5rem 2rem;
 }
 
 @media screen and (min-width: 768px) {
 	#home .thumb-list {
-		grid-template-columns: repeat(auto-fit, minmax(550px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(min(550px, 100%), 1fr));
 	}
 
 	#home .about p {


### PR DESCRIPTION
## Summary
Updated the CSS grid layout for the home page thumbnail list to prevent overflow on small screens by constraining the minimum column width to not exceed the viewport width.

## Changes
- Modified `.thumb-list` grid-template-columns to use `minmax(min(400px, 100%), 1fr)` instead of `minmax(400px, 1fr)` on mobile
- Applied the same fix to the tablet breakpoint (768px+), changing `minmax(550px, 1fr)` to `minmax(min(550px, 100%), 1fr)`

## Details
The `min()` function ensures that the minimum column width will be the smaller of either the specified pixel value (400px/550px) or 100% of the container width. This prevents grid items from overflowing their container on screens narrower than the minimum width, improving the responsive behavior on small devices while maintaining the intended layout on larger screens.

https://claude.ai/code/session_01781XVTxWYPB9CbXeeM4xfz